### PR TITLE
Added Framingham, Massachusetts and Newton, Massachusetts

### DIFF
--- a/src/cities.json
+++ b/src/cities.json
@@ -712,4 +712,6 @@
 "South Lake Tahoe|US|CA|38.93324|-119.98435|America/Los_Angeles|",
 "Truckee|US|CA|39.32796|-120.18325|America/Los_Angeles|",
 "Incline Village|US|NV|39.2513|-119.97297|America/Los_Angeles|",
+"Framingham|US|MA|42.32614|-71.42378|America/New_York|",
+"Newton|US|MA|42.33739|-71.2088|America/New_York|",
 "Plymouth|MS||16.70555|-62.21292|America/Montserrat|"]


### PR DESCRIPTION
Hi. I was hoping you might be willing to add Framingham and Newton to your Hebcal Alexa skill. It's a lot more elegant to ask for candle lighting times in "Framingham" or "Newton" than "01702" :-) Thanks for considering it! I know it's a bit of a pain to re-submit a skill that's already been approved. 